### PR TITLE
Authorize Release Conversations

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Zorgbort is going to make common tasks easier to do.
 SLACK_TOKEN="TOKEN"
 GITHUB_TOKEN="TOKEN"
 SSH_KEY_PASSPHRASE=="ZORGBORT Passphrase"
+VALID_RELEASE_USERS=="SLACKID,SLACKID2"
 ```
 5. Run ZORBORT with `npm start`
 5. test ZORBORT with `npm test`
@@ -24,6 +25,7 @@ SSH_KEY_PASSPHRASE=="ZORGBORT Passphrase"
 4. `heroku config:set SLACK_TOKEN="TOKEN"`
 5. `heroku config:set GITHUB_TOKEN="TOKEN"`
 5. `heroku config:set SSH_KEY_PASSPHRASE="ZORGBORT Passphrase"`
+5. `heroku config:set VALID_RELEASE_USERS="SLACKID,SLACKID2"`
 
 ## Acknowledgments
 

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -6,6 +6,7 @@ if (!process.env.SLACK_TOKEN) {
 const Botkit = require('botkit');
 const controller = Botkit.slackbot({
   debug: false,
+  require_delivery: true,
 });
 controller.spawn({
   token: process.env.SLACK_TOKEN

--- a/src/releaseAndTag.js
+++ b/src/releaseAndTag.js
@@ -165,7 +165,7 @@ const validateRequestAndStartConversation = async (bot, message, owner, repo) =>
 
 const releaseConversation = (bot, message, owner, repo) => {
   bot.startConversation(message, function(err, convo) {
-    convo.ask('Is this a feature or a bugfix release?', [
+    convo.ask(`Is this a feature or a bugfix release for ${owner}:${repo}?`, [
       {
         pattern: '(feature|bugfix)',
         callback: (response, convo) => {
@@ -174,9 +174,16 @@ const releaseConversation = (bot, message, owner, repo) => {
         }
       },
       {
+        pattern: '(stop|cancel|no|holdon|end|quit|die)',
+        callback: (response, convo) => {
+          convo.stop();
+        }
+      },
+      {
         default: true,
         callback: function(response, convo) {
           convo.say("Sorry that's not what I asked...");
+          convo.say("You can say 'feature', 'bugfix' or 'cancel'");
           convo.repeat();
           convo.next();
         }

--- a/src/releaseAndTag.js
+++ b/src/releaseAndTag.js
@@ -205,13 +205,13 @@ const releaseConversation = (bot, message, owner, repo) => {
   });
 };
 
-// module.exports = bot => {
-//   bot.hears('releaase frontend', 'direct_message,direct_mention,mention', (bot, message) => {
-//     const owner = 'ilios';
-//     const repo = 'frontend';
-//     releaseConversation(bot, message, owner, repo);
-//   });
-// };
+module.exports = bot => {
+  bot.hears('releaase the frontend', 'direct_message,direct_mention,mention', (bot, message) => {
+    const owner = 'ilios';
+    const repo = 'frontend';
+    validateRequestAndStartConversation(bot, message, owner, repo);
+  });
+};
 
 module.exports = bot => {
   bot.hears('test release', 'direct_message,direct_mention,mention', (bot, message) => {


### PR DESCRIPTION
Validate userId with slack before allowing actions.  Using the UserID should be a secure way to do this I hope.