### PR TITLE
Implement suggested security improvement

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -2,12 +2,27 @@
 if (!process.env.SLACK_TOKEN) {
   throw new Error('Error: Specify SLACK_TOKEN in environment');
 }
+if (!process.env.SLACK_CLIENT_ID) {
+  throw new Error('Error: Specify SLACK_CLIENT_ID in environment');
+}
+if (!process.env.SLACK_CLIENT_SECRET) {
+  throw new Error('Error: Specify SLACK_CLIENT_SECRET in environment');
+}
+if (!process.env.SLACK_SIGNING_SECRET) {
+  throw new Error('Error: Specify SLACK_SIGNING_SECRET in environment');
+}
 
 const Botkit = require('botkit');
-const controller = Botkit.slackbot({
-  debug: false,
-  require_delivery: true,
-});
+
+const options = {
+  clientId: process.env.SLACK_CLIENT_ID,
+  clientSecret: process.env.SLACK_CLIENT_SECRET,
+  clientSigningSecret: process.env.SLACK_SIGNING_SECRET,
+  debug: true,
+  scopes: ['bot'],
+};
+
+const controller = Botkit.slackbot(options);
 controller.spawn({
   token: process.env.SLACK_TOKEN
 }).startRTM();


### PR DESCRIPTION
Botkit warns about not validating messages at startup. This change
requires us to register zorgbort as an application, but now we're doing
a better job validating the source of incoming messages.