### PR TITLE
Increment lock file when bumping package version

### DIFF
--- a/lib/incrementPackageVersion.js
+++ b/lib/incrementPackageVersion.js
@@ -5,22 +5,41 @@ const fs = require('mz/fs');
 
 const incrementPackageVersion = async (dir, versionType) => {
   console.log(`Incrementing ${versionType} package version in ${dir}`);
-  const filePath = `${dir}/package.json`;
-  const json = await fs.readFile(filePath);
-  const data = JSON.parse(json);
-  const currentVersion = data.version;
-  const nextVersion = semver.inc(currentVersion, versionType);
-  console.log(`Taking ${filePath} from ${currentVersion} to ${nextVersion}`);
+  const packagePath = `${dir}/package.json`;
+  const { currentVersion, nextVersion } = await getVersionData(packagePath, versionType);
+  console.log(`Taking ${packagePath} from ${currentVersion} to ${nextVersion}`);
+  await writeFile(packagePath, nextVersion);
 
-  data.version = nextVersion;
-  const string = JSON.stringify(data, null, 2) + '\n';
-  await fs.writeFile(filePath, string);
-  console.log(`Writing new version to ${filePath}`);
+  const lockPath = `${dir}/package-lock.json`;
+  console.log(`Taking ${lockPath} from ${currentVersion} to ${nextVersion}`);
+  await writeFile(lockPath, nextVersion);
 
   return {
     currentVersion,
     nextVersion
   };
+};
+
+const getVersionData = async (filePath, versionType) => {
+  const json = await fs.readFile(filePath);
+  const data = JSON.parse(json);
+  const currentVersion = data.version;
+  const nextVersion = semver.inc(currentVersion, versionType);
+
+  return {
+    currentVersion,
+    nextVersion
+  };
+};
+
+const writeFile = async (filePath, nextVersion) => {
+  const json = await fs.readFile(filePath);
+  const data = JSON.parse(json);
+
+  data.version = nextVersion;
+  const string = JSON.stringify(data, null, 2) + '\n';
+  await fs.writeFile(filePath, string);
+  console.log(`Writing new version to ${filePath}`);
 };
 
 module.exports = incrementPackageVersion;

--- a/test/incrementPackageVersion.js
+++ b/test/incrementPackageVersion.js
@@ -8,7 +8,21 @@ const appRoot = require('app-root-path');
 
 describe('Increment Package Version', function() {
   const tmpDir = `${appRoot}/tmp`;
-  const filePath = `${tmpDir}/package.json`;
+  const packagePath = `${tmpDir}/package.json`;
+  const lockPath = `${tmpDir}/package-lock.json`;
+
+  const getVersionData = async function(){
+    const packageJson = await fs.readFile(packagePath);
+    const packageData = JSON.parse(packageJson);
+
+    const lockJson = await fs.readFile(packagePath);
+    const lockData = JSON.parse(lockJson);
+
+    return {
+      packageVersion: packageData.version,
+      lockVersion: lockData.version,
+    };
+  };
 
   before('create temporary directory', async function(){
     const exists = await fs.exists(tmpDir);
@@ -17,39 +31,46 @@ describe('Increment Package Version', function() {
     }
   }),
 
-  beforeEach('create package.json file', async function() {
-    await fs.writeFile(filePath, JSON.stringify({
+  beforeEach('create files', async function() {
+    await fs.writeFile(packagePath, JSON.stringify({
+      version: '1.0.0'
+    }));
+    await fs.writeFile(lockPath, JSON.stringify({
       version: '1.0.0'
     }));
   });
-  afterEach('remove package.json file', async function() {
-    await fs.unlink(filePath);
+  afterEach('remove files', async function() {
+    await fs.unlink(packagePath);
+    await fs.unlink(lockPath);
   });
   it('Increments Major', async function() {
     const { currentVersion, nextVersion } = await incrementPackageVersion(tmpDir, 'major');
     const targetVersion = '2.0.0';
     assert.equal(currentVersion, '1.0.0');
     assert.equal(nextVersion, targetVersion);
-    const json = await fs.readFile(filePath);
-    const data = JSON.parse(json);
-    assert.equal(data.version, targetVersion);
+
+    const { packageVersion, lockVersion } = await getVersionData();
+    assert.equal(packageVersion, targetVersion);
+    assert.equal(lockVersion, targetVersion);
   });
   it('Increments Minor', async function() {
     const { currentVersion, nextVersion } = await incrementPackageVersion(tmpDir, 'minor');
     const targetVersion = '1.1.0';
     assert.equal(currentVersion, '1.0.0');
     assert.equal(nextVersion, targetVersion);
-    const json = await fs.readFile(filePath);
-    const data = JSON.parse(json);
-    assert.equal(data.version, targetVersion);
+
+    const { packageVersion, lockVersion } = await getVersionData();
+    assert.equal(packageVersion, targetVersion);
+    assert.equal(lockVersion, targetVersion);
   });
   it('Increments Patch', async function() {
     const { currentVersion, nextVersion } = await incrementPackageVersion(tmpDir, 'patch');
     const targetVersion = '1.0.1';
     assert.equal(currentVersion, '1.0.0');
     assert.equal(nextVersion, targetVersion);
-    const json = await fs.readFile(filePath);
-    const data = JSON.parse(json);
-    assert.equal(data.version, targetVersion);
+
+    const { packageVersion, lockVersion } = await getVersionData();
+    assert.equal(packageVersion, targetVersion);
+    assert.equal(lockVersion, targetVersion);
   });
 });


### PR DESCRIPTION
NPM stores a copy of the version in the lock file so we need to
increment that as well.

Fixes #66