### PR TITLE
chore: Update botkit to 0.7.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,323 +24,6 @@
         "js-tokens": "^4.0.0"
       }
     },
-    "@ciscospark/common": {
-      "version": "1.32.23",
-      "resolved": "https://registry.npmjs.org/@ciscospark/common/-/common-1.32.23.tgz",
-      "integrity": "sha1-Z42nujRy55QLJuzqvALTEeCoof0=",
-      "requires": {
-        "babel-runtime": "^6.23.0",
-        "backoff": "^2.5.0",
-        "core-decorators": "^0.20.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.4",
-        "urlsafe-base64": "^1.0.0"
-      }
-    },
-    "@ciscospark/common-evented": {
-      "version": "1.32.23",
-      "resolved": "https://registry.npmjs.org/@ciscospark/common-evented/-/common-evented-1.32.23.tgz",
-      "integrity": "sha1-yFUrujAlT2gTO6sXCwxfUYG3zH8=",
-      "requires": {
-        "@ciscospark/common": "1.32.23",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0"
-      }
-    },
-    "@ciscospark/common-timers": {
-      "version": "1.32.23",
-      "resolved": "https://registry.npmjs.org/@ciscospark/common-timers/-/common-timers-1.32.23.tgz",
-      "integrity": "sha1-xB7qYS5h7m7RJO/sRz+BnOKaLnY=",
-      "requires": {
-        "envify": "^4.1.0"
-      }
-    },
-    "@ciscospark/http-core": {
-      "version": "1.32.23",
-      "resolved": "https://registry.npmjs.org/@ciscospark/http-core/-/http-core-1.32.23.tgz",
-      "integrity": "sha1-Ak5NGxXtc7Dtjkmogj3RNHtv8cs=",
-      "requires": {
-        "@ciscospark/common": "1.32.23",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "file-type": "^3.9.0",
-        "global": "^4.3.1",
-        "is-function": "^1.0.1",
-        "lodash": "^4.17.4",
-        "parse-headers": "^2.0.1",
-        "qs": "^6.5.1",
-        "request": "^2.81.0",
-        "xtend": "^4.0.1"
-      }
-    },
-    "@ciscospark/internal-plugin-feature": {
-      "version": "1.32.23",
-      "resolved": "https://registry.npmjs.org/@ciscospark/internal-plugin-feature/-/internal-plugin-feature-1.32.23.tgz",
-      "integrity": "sha1-Sni0V2TLrywNsVPgdYkmOUnRIeo=",
-      "requires": {
-        "@ciscospark/internal-plugin-wdm": "1.32.23",
-        "@ciscospark/spark-core": "1.32.23",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.4"
-      }
-    },
-    "@ciscospark/internal-plugin-locus": {
-      "version": "1.32.23",
-      "resolved": "https://registry.npmjs.org/@ciscospark/internal-plugin-locus/-/internal-plugin-locus-1.32.23.tgz",
-      "integrity": "sha1-30NLVkILow1W3gGgvFcHfiVLRf8=",
-      "requires": {
-        "@ciscospark/internal-plugin-mercury": "1.32.23",
-        "@ciscospark/spark-core": "1.32.23",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.4",
-        "uuid": "^3.2.1"
-      }
-    },
-    "@ciscospark/internal-plugin-mercury": {
-      "version": "1.32.23",
-      "resolved": "https://registry.npmjs.org/@ciscospark/internal-plugin-mercury/-/internal-plugin-mercury-1.32.23.tgz",
-      "integrity": "sha1-ppNtAk5fegUx7hXRsasXeD6maBA=",
-      "requires": {
-        "@ciscospark/common": "1.32.23",
-        "@ciscospark/common-timers": "1.32.23",
-        "@ciscospark/internal-plugin-feature": "1.32.23",
-        "@ciscospark/internal-plugin-metrics": "1.32.23",
-        "@ciscospark/internal-plugin-wdm": "1.32.23",
-        "@ciscospark/spark-core": "1.32.23",
-        "babel-runtime": "^6.23.0",
-        "backoff": "^2.5.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.4",
-        "uuid": "^3.2.1",
-        "ws": "^4.0.0"
-      },
-      "dependencies": {
-        "ws": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
-          "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
-          "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
-    "@ciscospark/internal-plugin-metrics": {
-      "version": "1.32.23",
-      "resolved": "https://registry.npmjs.org/@ciscospark/internal-plugin-metrics/-/internal-plugin-metrics-1.32.23.tgz",
-      "integrity": "sha1-ouM/8dua59XwBsgFaOM7I9bK3zY=",
-      "requires": {
-        "@ciscospark/common": "1.32.23",
-        "@ciscospark/common-timers": "1.32.23",
-        "@ciscospark/internal-plugin-wdm": "1.32.23",
-        "@ciscospark/spark-core": "1.32.23",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0"
-      }
-    },
-    "@ciscospark/internal-plugin-wdm": {
-      "version": "1.32.23",
-      "resolved": "https://registry.npmjs.org/@ciscospark/internal-plugin-wdm/-/internal-plugin-wdm-1.32.23.tgz",
-      "integrity": "sha1-6fiimAoVx4bDXgW1J0SEJ4GBxfk=",
-      "requires": {
-        "@ciscospark/common": "1.32.23",
-        "@ciscospark/common-timers": "1.32.23",
-        "@ciscospark/http-core": "1.32.23",
-        "@ciscospark/spark-core": "1.32.23",
-        "ampersand-collection": "^2.0.2",
-        "ampersand-state": "^5.0.2",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.4"
-      }
-    },
-    "@ciscospark/media-engine-webrtc": {
-      "version": "1.32.23",
-      "resolved": "https://registry.npmjs.org/@ciscospark/media-engine-webrtc/-/media-engine-webrtc-1.32.23.tgz",
-      "integrity": "sha1-O9Eg2hnIl2N8hrx1mpnPvZ89/4A=",
-      "requires": {
-        "@ciscospark/common": "1.32.23",
-        "@ciscospark/common-evented": "1.32.23",
-        "ampersand-events": "^2.0.2",
-        "babel-runtime": "^6.23.0",
-        "bowser": "^1.6.0",
-        "core-decorators": "^0.20.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.4",
-        "lodash-decorators": "^4.3.4",
-        "sdp-transform": "^2.4.0",
-        "webrtc-adapter": "^6.1.0"
-      }
-    },
-    "@ciscospark/plugin-authorization": {
-      "version": "1.32.23",
-      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-authorization/-/plugin-authorization-1.32.23.tgz",
-      "integrity": "sha1-EgVk9NpwxW5Uyql/rehNGfMj340=",
-      "requires": {
-        "@ciscospark/plugin-authorization-browser": "1.32.23",
-        "@ciscospark/plugin-authorization-node": "1.32.23",
-        "envify": "^4.1.0"
-      }
-    },
-    "@ciscospark/plugin-authorization-browser": {
-      "version": "1.32.23",
-      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-authorization-browser/-/plugin-authorization-browser-1.32.23.tgz",
-      "integrity": "sha1-AawbHvzEu8AN6pY4ElgI/rotsVw=",
-      "requires": {
-        "@ciscospark/common": "1.32.23",
-        "@ciscospark/internal-plugin-wdm": "1.32.23",
-        "@ciscospark/spark-core": "1.32.23",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.4",
-        "uuid": "^3.2.1"
-      }
-    },
-    "@ciscospark/plugin-authorization-node": {
-      "version": "1.32.23",
-      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-authorization-node/-/plugin-authorization-node-1.32.23.tgz",
-      "integrity": "sha1-bbC0hVTaTd1j8DimDb3pouTyvvw=",
-      "requires": {
-        "@ciscospark/common": "1.32.23",
-        "@ciscospark/internal-plugin-wdm": "1.32.23",
-        "@ciscospark/spark-core": "1.32.23",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0"
-      }
-    },
-    "@ciscospark/plugin-logger": {
-      "version": "1.32.23",
-      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-logger/-/plugin-logger-1.32.23.tgz",
-      "integrity": "sha1-with7ce3khtqJcE4I+yBBJUZtCg=",
-      "requires": {
-        "@ciscospark/common": "1.32.23",
-        "@ciscospark/spark-core": "1.32.23",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.4"
-      }
-    },
-    "@ciscospark/plugin-memberships": {
-      "version": "1.32.23",
-      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-memberships/-/plugin-memberships-1.32.23.tgz",
-      "integrity": "sha1-LnhOSAxozq5dljKu+CIkgqGrPEc=",
-      "requires": {
-        "@ciscospark/spark-core": "1.32.23",
-        "envify": "^4.1.0"
-      }
-    },
-    "@ciscospark/plugin-messages": {
-      "version": "1.32.23",
-      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-messages/-/plugin-messages-1.32.23.tgz",
-      "integrity": "sha1-xCQN7Ewh/uxlSPujemnKSxN8w+U=",
-      "requires": {
-        "@ciscospark/spark-core": "1.32.23",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.4"
-      }
-    },
-    "@ciscospark/plugin-people": {
-      "version": "1.32.23",
-      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-people/-/plugin-people-1.32.23.tgz",
-      "integrity": "sha1-5hy90mlkurczdfICOQS1O20C0fo=",
-      "requires": {
-        "@ciscospark/common": "1.32.23",
-        "@ciscospark/spark-core": "1.32.23",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0"
-      }
-    },
-    "@ciscospark/plugin-phone": {
-      "version": "1.32.23",
-      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-phone/-/plugin-phone-1.32.23.tgz",
-      "integrity": "sha1-TdCA2mlHLuPAYEPn8shpZcZ6gjc=",
-      "requires": {
-        "@ciscospark/common": "1.32.23",
-        "@ciscospark/common-timers": "1.32.23",
-        "@ciscospark/internal-plugin-locus": "1.32.23",
-        "@ciscospark/internal-plugin-metrics": "1.32.23",
-        "@ciscospark/media-engine-webrtc": "1.32.23",
-        "@ciscospark/plugin-people": "1.32.23",
-        "@ciscospark/spark-core": "1.32.23",
-        "ampersand-collection": "^2.0.2",
-        "ampersand-collection-lodash-mixin": "^4.0.0",
-        "ampersand-state": "^5.0.2",
-        "babel-runtime": "^6.23.0",
-        "detectrtc": "^1.3.4",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.4",
-        "lodash-decorators": "^4.3.4",
-        "sdp-transform": "^2.4.0",
-        "uuid": "^3.2.1"
-      }
-    },
-    "@ciscospark/plugin-rooms": {
-      "version": "1.32.23",
-      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-rooms/-/plugin-rooms-1.32.23.tgz",
-      "integrity": "sha1-hGpv+DZa/nh45v83WBLNEdEfM10=",
-      "requires": {
-        "@ciscospark/spark-core": "1.32.23",
-        "envify": "^4.1.0"
-      }
-    },
-    "@ciscospark/plugin-team-memberships": {
-      "version": "1.32.23",
-      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-team-memberships/-/plugin-team-memberships-1.32.23.tgz",
-      "integrity": "sha1-ZKCtWn6utOT8I3G2F8/Frg3gyAg=",
-      "requires": {
-        "@ciscospark/spark-core": "1.32.23",
-        "envify": "^4.1.0"
-      }
-    },
-    "@ciscospark/plugin-teams": {
-      "version": "1.32.23",
-      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-teams/-/plugin-teams-1.32.23.tgz",
-      "integrity": "sha1-VLP5egI2iiv9VP3SjGIWBpUlFmI=",
-      "requires": {
-        "@ciscospark/spark-core": "1.32.23",
-        "envify": "^4.1.0"
-      }
-    },
-    "@ciscospark/plugin-webhooks": {
-      "version": "1.32.23",
-      "resolved": "https://registry.npmjs.org/@ciscospark/plugin-webhooks/-/plugin-webhooks-1.32.23.tgz",
-      "integrity": "sha1-bRAsA9Nf1MHWzwwHYdIImHndu3E=",
-      "requires": {
-        "@ciscospark/spark-core": "1.32.23",
-        "envify": "^4.1.0"
-      }
-    },
-    "@ciscospark/spark-core": {
-      "version": "1.32.23",
-      "resolved": "https://registry.npmjs.org/@ciscospark/spark-core/-/spark-core-1.32.23.tgz",
-      "integrity": "sha1-hrdSNpl7XsXGKVkpPDRucyWknrk=",
-      "requires": {
-        "@ciscospark/common": "1.32.23",
-        "@ciscospark/common-timers": "1.32.23",
-        "@ciscospark/http-core": "1.32.23",
-        "ampersand-collection": "^2.0.2",
-        "ampersand-events": "^2.0.2",
-        "ampersand-state": "^5.0.2",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.4",
-        "uuid": "^3.2.1"
-      }
-    },
-    "@ciscospark/storage-adapter-local-storage": {
-      "version": "1.32.23",
-      "resolved": "https://registry.npmjs.org/@ciscospark/storage-adapter-local-storage/-/storage-adapter-local-storage-1.32.23.tgz",
-      "integrity": "sha1-tZH36p2ySfpn5D8U8n7v8MYQnws=",
-      "requires": {
-        "@ciscospark/spark-core": "1.32.23",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0"
-      }
-    },
     "@octokit/endpoint": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-3.1.2.tgz",
@@ -380,9 +63,9 @@
       }
     },
     "@types/async": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@types/async/-/async-2.4.0.tgz",
-      "integrity": "sha512-1/6EglKPJZjkj2KWSFrvbOeqDZTb+KEiU293MUwc/z3/g4a+jOPADHfcOzt/EbY0uEEr+dkUWTYQfVDzzOrMaw=="
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@types/async/-/async-2.4.2.tgz",
+      "integrity": "sha512-bWBbC7VG2jdjbgZMX0qpds8U/3h3anfIqE81L8jmVrgFZw/urEDnBA78ymGGKTTK6ciBXmmJ/xlok+Re41S8ww=="
     },
     "@types/body-parser": {
       "version": "1.17.0",
@@ -394,9 +77,9 @@
       }
     },
     "@types/caseless": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.1.tgz",
-      "integrity": "sha512-FhlMa34NHp9K5MY1Uz8yb+ZvuX0pnvn3jScRSNAb75KHGB8d3rEU6hqMs3Z2vjuytcMfRg6c5CHMc3wtYyD2/A=="
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
+      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
     },
     "@types/connect": {
       "version": "3.4.32",
@@ -407,9 +90,9 @@
       }
     },
     "@types/express": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.16.1.tgz",
-      "integrity": "sha512-V0clmJow23WeyblmACoxbHBu2JKlE5TiIme6Lem14FnPW9gsttyHtk6wq7njcdIWH1njAaFgR8gW09lgY98gQg==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.0.tgz",
+      "integrity": "sha512-CjaMu57cjgjuZbh9DpkloeGxV45CnMGlVd+XpG7Gm9QgVrd7KFq+X4HY0vM+2v0bczS48Wg7bvnMY5TN+Xmcfw==",
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "*",
@@ -417,9 +100,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.1.tgz",
-      "integrity": "sha512-QgbIMRU1EVRry5cIu1ORCQP4flSYqLM1lS5LYyGWfKnFT3E58f0gKto7BR13clBFVrVZ0G0rbLZ1hUpSkgQQOA==",
+      "version": "4.16.7",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.7.tgz",
+      "integrity": "sha512-847KvL8Q1y3TtFLRTXcVakErLJQgdpFSaq+k043xefz9raEf0C7HalpSY7OW5PyjCnY8P7bPW5t/Co9qqp+USg==",
       "requires": {
         "@types/node": "*",
         "@types/range-parser": "*"
@@ -447,9 +130,9 @@
       "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
     },
     "@types/node": {
-      "version": "9.6.42",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.42.tgz",
-      "integrity": "sha512-SpeVQJFekfnEaZZO1yl4je/36upII36L7gOT4DBx51B1GeAB45mmDb3a5OBQB+ZeFxVVOP37r8Owsl940G/fBg=="
+      "version": "9.6.49",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.49.tgz",
+      "integrity": "sha512-YY0Okyn4QXC4ugJI+Kng5iWjK8A6eIHiQVaGIhJkyn0YL6Iqo0E0tBC8BuhvYcBK87vykBijM5FtMnCqaa5anA=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -477,9 +160,9 @@
       }
     },
     "@types/sprintf-js": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/sprintf-js/-/sprintf-js-1.1.1.tgz",
-      "integrity": "sha512-h8jF5yPUoHH1QUIDfHgqFs7Y0UykKB5CJ1Z32PHGmHRLmW0pI+kYKAEnXVqeUZ3ygFmDkyvhD4vUZN+RZyTd1w=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-hkgzYF+qnIl8uTO8rmUSVSfQ8BIfMXC4yJAF4n8BE758YsKBZvFC4NumnAegj7KmylP0liEZNpb9RRGFMbFejA=="
     },
     "@types/tough-cookie": {
       "version": "2.3.5",
@@ -490,6 +173,460 @@
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/@types/url-join/-/url-join-0.8.3.tgz",
       "integrity": "sha512-bM7dzLHuCqDNlbeOxvo/KfweN3La4d9C1VFGCgefxiZXn0JcRtyGDwWCSUEO8RrMhnx/LGhDOXP8TTokM1grSA=="
+    },
+    "@webex/common": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-1.59.0.tgz",
+      "integrity": "sha512-HKL+U1Jia3Pg1XPV36NozBJe7yZIgAlaKfrnzt3i5JbQvtiLXCijvu5+o3plEuI/AFv2/04D67jql1DG8YXASw==",
+      "requires": {
+        "@webex/common": "1.59.0",
+        "babel-runtime": "^6.23.0",
+        "backoff": "^2.5.0",
+        "core-decorators": "^0.20.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11",
+        "urlsafe-base64": "^1.0.0"
+      }
+    },
+    "@webex/common-evented": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@webex/common-evented/-/common-evented-1.59.0.tgz",
+      "integrity": "sha512-u7A00gJoqgz1y8s1ACWO5q1JrquAF89I8FO6e9C1w/SlXZnIYYSD4X216dzNYnX/uBDNXS2ePkklnWyH0YvBYw==",
+      "requires": {
+        "@webex/common": "1.59.0",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/common-timers": {
+      "version": "1.58.5",
+      "resolved": "https://registry.npmjs.org/@webex/common-timers/-/common-timers-1.58.5.tgz",
+      "integrity": "sha512-DwP0G4Ab4jdnub2Paxm01JKCn0BDM9hzKvvVc6eWm50/alzZH0Np8wv6MgMu5/wc3UqYLsHTJ6W6JzMW9xcNZw==",
+      "requires": {
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/helper-html": {
+      "version": "1.58.5",
+      "resolved": "https://registry.npmjs.org/@webex/helper-html/-/helper-html-1.58.5.tgz",
+      "integrity": "sha512-3wMtZaMFc+IJ1vEdjwlflNezuEUWL7gQR6OPg7nS5+Q38Rp5UPlCpPoCXZXfZu3ECcfpl8HakBuhbUwicF1Dbw==",
+      "requires": {
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11"
+      }
+    },
+    "@webex/helper-image": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@webex/helper-image/-/helper-image-1.59.0.tgz",
+      "integrity": "sha512-AvQckU+DwIAOgyU7VyHQ0SQ17kHeRiwEopE6C0X02pG9LJG+7Z/MGDV9wnGnqL/Utf59UnMCDECYMwdczrikqw==",
+      "requires": {
+        "@webex/http-core": "1.59.0",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "exif": "^0.6.0",
+        "gm": "^1.23.0",
+        "lodash": "^4.17.11",
+        "mime-types": "^2.1.15"
+      }
+    },
+    "@webex/http-core": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@webex/http-core/-/http-core-1.59.0.tgz",
+      "integrity": "sha512-JDtUEKkPPAWsSJNLULTOydkZsRLPFEuFmL3PWpm7Gezp/XiiBSQLHjZo1wBe2kK2LTYGb9//bEXcmpZy095u5g==",
+      "requires": {
+        "@webex/common": "1.59.0",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "file-type": "^3.9.0",
+        "global": "^4.3.1",
+        "is-function": "^1.0.1",
+        "lodash": "^4.17.11",
+        "parse-headers": "^2.0.1",
+        "qs": "^6.5.1",
+        "request": "^2.81.0",
+        "xtend": "^4.0.1"
+      }
+    },
+    "@webex/internal-plugin-conversation": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-conversation/-/internal-plugin-conversation-1.59.0.tgz",
+      "integrity": "sha512-uQQNpVV2E7h+G2GNxQbyFvA9wMT4aCKN2AMF8cJN4oy90DInDcvKWnsR7XrFHoGuZu4g5pGM9RFZrHyp3FhkSA==",
+      "requires": {
+        "@webex/common": "1.59.0",
+        "@webex/helper-html": "1.58.5",
+        "@webex/helper-image": "1.59.0",
+        "@webex/internal-plugin-encryption": "1.59.0",
+        "@webex/internal-plugin-user": "1.59.0",
+        "@webex/webex-core": "1.59.0",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11",
+        "uuid": "^3.2.1"
+      }
+    },
+    "@webex/internal-plugin-encryption": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-encryption/-/internal-plugin-encryption-1.59.0.tgz",
+      "integrity": "sha512-rafd2UgAOvz1oCaOthO/jmcjCknlcgKgdJbqBxu5juqkZpnnGiWQB4UJN8hPQtD2HgRRzgozGQiP+akAKmbAvw==",
+      "requires": {
+        "@webex/common": "1.59.0",
+        "@webex/common-timers": "1.58.5",
+        "@webex/http-core": "1.59.0",
+        "@webex/internal-plugin-mercury": "1.59.0",
+        "@webex/internal-plugin-wdm": "1.59.0",
+        "@webex/webex-core": "1.59.0",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11",
+        "node-jose": "^0.11.0",
+        "node-kms": "^0.3.2",
+        "node-scr": "^0.2.2"
+      }
+    },
+    "@webex/internal-plugin-feature": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-feature/-/internal-plugin-feature-1.59.0.tgz",
+      "integrity": "sha512-P7UH9bEM484KtlgQgrfbPTY6JcaRAtgmc9HGRn+Mx+aautlgtSMrjIeDLfvgRdLZCFuDDHboz3q3lP7T8eaF8g==",
+      "requires": {
+        "@webex/internal-plugin-wdm": "1.59.0",
+        "@webex/webex-core": "1.59.0",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11"
+      }
+    },
+    "@webex/internal-plugin-locus": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-locus/-/internal-plugin-locus-1.59.0.tgz",
+      "integrity": "sha512-b4NBq1UCsfMU86AxPN0XsXSsls87ijj3U7u+ADB0snn9T5OnZ+yF50CvP6aNDplhAdmtJf6bZ5wtb13moo14rQ==",
+      "requires": {
+        "@webex/internal-plugin-mercury": "1.59.0",
+        "@webex/webex-core": "1.59.0",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11",
+        "uuid": "^3.2.1"
+      }
+    },
+    "@webex/internal-plugin-mercury": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-mercury/-/internal-plugin-mercury-1.59.0.tgz",
+      "integrity": "sha512-hMf4MlE70F7dkIZZHbkQ+ie6GZ9BpeB6rvBUJPLu66ofNNKm6AVhbtgqHiEN9IEkMndzanF1VCs3vSFdhbXyDQ==",
+      "requires": {
+        "@webex/common": "1.59.0",
+        "@webex/common-timers": "1.58.5",
+        "@webex/internal-plugin-feature": "1.59.0",
+        "@webex/internal-plugin-metrics": "1.59.0",
+        "@webex/internal-plugin-wdm": "1.59.0",
+        "@webex/webex-core": "1.59.0",
+        "babel-runtime": "^6.23.0",
+        "backoff": "^2.5.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11",
+        "uuid": "^3.2.1",
+        "ws": "^4.0.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+          "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+          "requires": {
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "@webex/internal-plugin-metrics": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-metrics/-/internal-plugin-metrics-1.59.0.tgz",
+      "integrity": "sha512-fLwTJAIjkNSupNBXvZ8gOofbS20+htgfvoSI9DvqNm+aZxvEBFsxqfAi2fVg+EDdAK38F/mvfNOW9tVpXum4kg==",
+      "requires": {
+        "@webex/common": "1.59.0",
+        "@webex/common-timers": "1.58.5",
+        "@webex/internal-plugin-wdm": "1.59.0",
+        "@webex/webex-core": "1.59.0",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/internal-plugin-user": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-user/-/internal-plugin-user-1.59.0.tgz",
+      "integrity": "sha512-z3c0TogmGQmmBQUUFPGMN8ODmayuey3pwOUtFMbvzSOSb35U5/xTOptucW63BYROgdOx668uPeO+adDQ0opmyg==",
+      "requires": {
+        "@webex/common": "1.59.0",
+        "@webex/internal-plugin-wdm": "1.59.0",
+        "@webex/webex-core": "1.59.0",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11"
+      }
+    },
+    "@webex/internal-plugin-wdm": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-wdm/-/internal-plugin-wdm-1.59.0.tgz",
+      "integrity": "sha512-Vw1A5g/Z3bSip2otTwNmLhNYzsYUVtiSp53NhYA5NaaJis0TvGYbuQtoEoQ0Sxwks4bGoJXZbxBK87N48noIlg==",
+      "requires": {
+        "@webex/common": "1.59.0",
+        "@webex/common-timers": "1.58.5",
+        "@webex/http-core": "1.59.0",
+        "@webex/webex-core": "1.59.0",
+        "ampersand-collection": "^2.0.2",
+        "ampersand-state": "^5.0.2",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11"
+      }
+    },
+    "@webex/media-engine-webrtc": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@webex/media-engine-webrtc/-/media-engine-webrtc-1.59.0.tgz",
+      "integrity": "sha512-9TNdDq3ADTZZzVIOgp1p634dOwKRdLfUPCdJ3QO4hHoDsbC+AX8OX25s2PilyMP57FFQPFK5/A7ibvTvyo3Fgw==",
+      "requires": {
+        "@webex/common": "1.59.0",
+        "@webex/common-evented": "1.59.0",
+        "ampersand-events": "^2.0.2",
+        "babel-runtime": "^6.23.0",
+        "bowser": "1.9.4",
+        "core-decorators": "^0.20.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11",
+        "lodash-decorators": "^4.3.4",
+        "sdp-transform": "^2.4.0",
+        "webrtc-adapter": "^6.1.0"
+      }
+    },
+    "@webex/plugin-authorization": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization/-/plugin-authorization-1.59.0.tgz",
+      "integrity": "sha512-S8PHaiPQrp3eakEazrxPzjrhxjrupByqu51d7zRF/hYOnMrV7zeW2z//yLwY+0ctO99JUcIqVvCpGWcK39p54w==",
+      "requires": {
+        "@webex/plugin-authorization-browser": "1.59.0",
+        "@webex/plugin-authorization-node": "1.59.0",
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/plugin-authorization-browser": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-browser/-/plugin-authorization-browser-1.59.0.tgz",
+      "integrity": "sha512-Vou55PXJok+WAa5TemoR4nuzWXJ9Bnphx9KakYJPxF5Oo4Vi4O43+IqCgcI4Oh7hQZr7kxn7OfG0jala3iNyfw==",
+      "requires": {
+        "@webex/common": "1.59.0",
+        "@webex/internal-plugin-wdm": "1.59.0",
+        "@webex/webex-core": "1.59.0",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11",
+        "uuid": "^3.2.1"
+      }
+    },
+    "@webex/plugin-authorization-node": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-node/-/plugin-authorization-node-1.59.0.tgz",
+      "integrity": "sha512-NLm2g64B4FP1aKZc57V53bzEydG02cxo4UZvd3YwaRY6vQ4vHx5wOEkldfJIXtMXxAwf55ew6iZp8iwthxbhCQ==",
+      "requires": {
+        "@webex/common": "1.59.0",
+        "@webex/internal-plugin-wdm": "1.59.0",
+        "@webex/webex-core": "1.59.0",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/plugin-logger": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-logger/-/plugin-logger-1.59.0.tgz",
+      "integrity": "sha512-AfJBs0nqzlIwiaalfyCiz23NeXx7N8D9HuflftyHGvCZNxq4vLmx7wmfP/QIe2YyaxKHr27a1xnl6cXnEIiECw==",
+      "requires": {
+        "@webex/common": "1.59.0",
+        "@webex/webex-core": "1.59.0",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11"
+      }
+    },
+    "@webex/plugin-memberships": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-memberships/-/plugin-memberships-1.59.0.tgz",
+      "integrity": "sha512-c28+5/hhW5ISdoEuzZ3vwYnVdaLXmenNEDV+8KwbZV65SX60k7at1TGRw5Kj1wkcFmzHEyJAYnPq7fkDmSSwdA==",
+      "requires": {
+        "@webex/common": "1.59.0",
+        "@webex/internal-plugin-conversation": "1.59.0",
+        "@webex/internal-plugin-mercury": "1.59.0",
+        "@webex/webex-core": "1.59.0",
+        "babel-runtime": "^6.23.0",
+        "debug": "^3.1.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "@webex/plugin-messages": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-messages/-/plugin-messages-1.59.0.tgz",
+      "integrity": "sha512-FxUz0JZtPNPH4UddZ69BM7Rd8k0QEyrvLQ6PfCDpWbhYtMbtIVbf+NB6jFQZrI780CjwW7G3mKb/KTQpx9oxQQ==",
+      "requires": {
+        "@webex/common": "1.59.0",
+        "@webex/internal-plugin-conversation": "1.59.0",
+        "@webex/internal-plugin-mercury": "1.59.0",
+        "@webex/webex-core": "1.59.0",
+        "babel-runtime": "^6.23.0",
+        "debug": "^3.1.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "@webex/plugin-people": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-people/-/plugin-people-1.59.0.tgz",
+      "integrity": "sha512-wu61+XpH32DhnmngfbexN1YCfqXOPhv1wuQsDjXjNTQaQpzNRB6kLhBxnQdUGtruDnOEPO5DS+kCYOlyLqqTCg==",
+      "requires": {
+        "@webex/common": "1.59.0",
+        "@webex/webex-core": "1.59.0",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/plugin-phone": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-phone/-/plugin-phone-1.59.0.tgz",
+      "integrity": "sha512-ofCyr0NxwiBXAkZHhHmLAa4Y1bIS+fmk7Vempay33itmk3L75WQdc9gCMM6mV6e60Z6whHy9Enkejc18Vvb1/Q==",
+      "requires": {
+        "@webex/common": "1.59.0",
+        "@webex/common-timers": "1.58.5",
+        "@webex/internal-plugin-locus": "1.59.0",
+        "@webex/internal-plugin-metrics": "1.59.0",
+        "@webex/media-engine-webrtc": "1.59.0",
+        "@webex/plugin-people": "1.59.0",
+        "@webex/webex-core": "1.59.0",
+        "ampersand-collection": "^2.0.2",
+        "ampersand-collection-lodash-mixin": "^4.0.0",
+        "ampersand-state": "^5.0.2",
+        "babel-runtime": "^6.23.0",
+        "detectrtc": "^1.3.4",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11",
+        "lodash-decorators": "^4.3.4",
+        "sdp-transform": "^2.4.0",
+        "uuid": "^3.2.1"
+      }
+    },
+    "@webex/plugin-rooms": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-rooms/-/plugin-rooms-1.59.0.tgz",
+      "integrity": "sha512-raYJ/qNXlveqTfaq2Zv6hqnTHgw1M6/fMAnWZgmOIOSr3bNBnmxpZb3wyFetGh2/NZD2SuXHC/b0Ox0euUZ8vw==",
+      "requires": {
+        "@webex/common": "1.59.0",
+        "@webex/internal-plugin-conversation": "1.59.0",
+        "@webex/internal-plugin-mercury": "1.59.0",
+        "@webex/webex-core": "1.59.0",
+        "babel-runtime": "^6.23.0",
+        "debug": "^3.1.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "@webex/plugin-team-memberships": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-team-memberships/-/plugin-team-memberships-1.59.0.tgz",
+      "integrity": "sha512-UMaHAQz+qMeZrr3JGzpCy96qq2BzjolVrYxj4RnbWL7pJc12xaZZLvLjjNPirpmGsqpZKeMavusw6dp+S7Em6Q==",
+      "requires": {
+        "@webex/webex-core": "1.59.0",
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/plugin-teams": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-teams/-/plugin-teams-1.59.0.tgz",
+      "integrity": "sha512-tc8wjAi+ZvukX1xHFGIJ+STFu/UtLo1n4CWi7SDk7uWC4lP9CMcjswYlT5Lohyt66I9F1q4KiWdhksbmqrRLeA==",
+      "requires": {
+        "@webex/webex-core": "1.59.0",
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/plugin-webhooks": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-webhooks/-/plugin-webhooks-1.59.0.tgz",
+      "integrity": "sha512-h+tX+X00LOdsbnmVdyhxMnM7pyO27kYBoKR1IqKBdBRr+TX+zUmfSaUFtjUlDVaArYh/vQTdDGCSr5vb/O2v3A==",
+      "requires": {
+        "@webex/webex-core": "1.59.0",
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/storage-adapter-local-storage": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@webex/storage-adapter-local-storage/-/storage-adapter-local-storage-1.59.0.tgz",
+      "integrity": "sha512-gkAk0/IFc9n3UC0bht0R5kGQlXtTqS1w4Y93x7B61fvOuFJZLYLdaqtZb/ZNS86pTkKWg2UkS/vlx/MXyJjwJQ==",
+      "requires": {
+        "@webex/webex-core": "1.59.0",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/webex-core": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@webex/webex-core/-/webex-core-1.59.0.tgz",
+      "integrity": "sha512-VHVHQ3X2UWT2Jf/ZoNGcxCg6UmuOY2OCi/+lD9fesIVLTHFptJiCt0k5NOFd9w042eSfsTfu3FjFLavwiPKvlQ==",
+      "requires": {
+        "@webex/common": "1.59.0",
+        "@webex/common-timers": "1.58.5",
+        "@webex/http-core": "1.59.0",
+        "@webex/webex-core": "1.59.0",
+        "ampersand-collection": "^2.0.2",
+        "ampersand-events": "^2.0.2",
+        "ampersand-state": "^5.0.2",
+        "babel-runtime": "^6.23.0",
+        "core-decorators": "^0.20.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11",
+        "uuid": "^3.2.1"
+      }
     },
     "@xmpp/jid": {
       "version": "0.0.2",
@@ -521,20 +658,35 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "abort-controller": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-2.0.2.tgz",
-      "integrity": "sha512-JXEYGxxMwiNl9EUdLysK0K0DwB7ENw6KeeaLHgofijTfJYPB/vOer3Mb+IcP913dCfWiQsd05MmVNl0H5PanrQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "requires": {
         "event-target-shim": "^5.0.0"
       }
     },
     "accepts": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
-      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
       "requires": {
-        "mime-types": "~2.1.18",
-        "negotiator": "0.6.1"
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.40.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+          "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+        },
+        "mime-types": {
+          "version": "2.1.24",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+          "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+          "requires": {
+            "mime-db": "1.40.0"
+          }
+        }
       }
     },
     "acorn": {
@@ -550,9 +702,9 @@
       "dev": true
     },
     "agent-base": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
       "requires": {
         "es6-promisify": "^5.0.0"
       }
@@ -720,22 +872,10 @@
         }
       }
     },
-    "argv-tools": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/argv-tools/-/argv-tools-0.1.1.tgz",
-      "integrity": "sha512-Cc0dBvx4dvrjjKpyDA6w8RlNAw8Su30NvZbWl/Tv9ZALEVlLVkWQiHMi84Q0xNfpVuSaiQbYkdmWK8g1PLGhKw==",
-      "requires": {
-        "array-back": "^2.0.0",
-        "find-replace": "^2.0.1"
-      }
-    },
     "array-back": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-      "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-      "requires": {
-        "typical": "^2.6.1"
-      }
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
     },
     "array-find-index": {
       "version": "1.0.2",
@@ -751,6 +891,16 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/array-next/-/array-next-0.0.1.tgz",
       "integrity": "sha1-5eRmCkwn/agVH/d2QnXQCQAGK+E="
+    },
+    "array-parallel": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/array-parallel/-/array-parallel-0.1.3.tgz",
+      "integrity": "sha1-j3hTCJJu1apHjEfmTRszS2wMlH0="
+    },
+    "array-series": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/array-series/-/array-series-0.1.5.tgz",
+      "integrity": "sha1-3103v8XC7wdV4qpPkv6ufUtaly8="
     },
     "arrify": {
       "version": "1.0.1",
@@ -810,13 +960,18 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "axios": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
-      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+      "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
       "requires": {
-        "follow-redirects": "^1.3.0",
-        "is-buffer": "^1.1.5"
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
       }
+    },
+    "b64u": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/b64u/-/b64u-2.0.0.tgz",
+      "integrity": "sha512-N3SnhKhQtwm9a4+rdNT0JvnNdPlRwpQZN4tfJwOE3/qJVzM+OlYj/Iz2n1S3KXAQmKHaRwWUNW5gEnjuD8cXHg=="
     },
     "babel-polyfill": {
       "version": "6.26.0",
@@ -927,20 +1082,20 @@
       }
     },
     "body-parser": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
-      "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
       "requires": {
-        "bytes": "3.0.0",
+        "bytes": "3.1.0",
         "content-type": "~1.0.4",
         "debug": "2.6.9",
         "depd": "~1.1.2",
-        "http-errors": "~1.6.3",
-        "iconv-lite": "0.4.23",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
         "on-finished": "~2.3.0",
-        "qs": "6.5.2",
-        "raw-body": "2.3.3",
-        "type-is": "~1.6.16"
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
+        "type-is": "~1.6.17"
       },
       "dependencies": {
         "debug": {
@@ -950,6 +1105,19 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
         }
       }
     },
@@ -985,9 +1153,9 @@
       }
     },
     "botkit": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/botkit/-/botkit-0.7.2.tgz",
-      "integrity": "sha512-Jt2eKdg0dMf0cXlsm0LHqBZ4wi+35zDbfnNQVelgi8h5HdBUwRCfuxPcsB4Mv7ZyD4aJerMFs6iypcdK+F49HA==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/botkit/-/botkit-0.7.4.tgz",
+      "integrity": "sha512-HMVWQ4fY6Xyb62SrFrEbBgKDaJiT7gbs2lva4SPdoq47jFkzgJ1wDKqkTsW+p+WMSVsHx9OaLKwyzxkrr0t6Gg==",
       "requires": {
         "async": "^2.6.1",
         "back": "^1.0.2",
@@ -995,7 +1163,7 @@
         "botbuilder": "^3.16.0",
         "botkit-studio-sdk": "^1.0.8",
         "chalk": "^2.4.1",
-        "ciscospark": "^1.32.23",
+        "ciscospark": "^1.48.0",
         "clone": "2.1.2",
         "command-line-args": "^5.0.2",
         "command-line-usage": "^5.0.5",
@@ -1035,9 +1203,9 @@
       },
       "dependencies": {
         "promise": {
-          "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.2.tgz",
-          "integrity": "sha512-EIyzM39FpVOMbqgzEHhxdrEhtOSDOtjMZQ0M6iVfCE+kWNgCkAyOdnuCWqfmflylftfadU6FkiMgHZA2kUzwRw==",
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.3.tgz",
+          "integrity": "sha512-HeRDUL1RJiLhyA0/grn+PTShlBAcLuh/1BJGtrvjwbvRDCTLLMEz9rOGCV+R3vHY4MixIuoMEd9Yq/XvsTPcjw==",
           "requires": {
             "asap": "~2.0.6"
           }
@@ -1109,9 +1277,9 @@
       "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
     },
     "bytes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
     },
     "callsites": {
       "version": "3.0.0",
@@ -1202,26 +1370,26 @@
       "dev": true
     },
     "ciscospark": {
-      "version": "1.32.23",
-      "resolved": "https://registry.npmjs.org/ciscospark/-/ciscospark-1.32.23.tgz",
-      "integrity": "sha1-uP3+EqOXIL1ZzIAJV+au5bmc7No=",
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/ciscospark/-/ciscospark-1.59.0.tgz",
+      "integrity": "sha512-uozxQp0KUFCtl/P2jE/aiSizahOAue9qxQH0fguR0wT+WZXkOaP4Aqan7sgIbQVRgP4h/S49LVLA787mfVGSpg==",
       "requires": {
-        "@ciscospark/internal-plugin-wdm": "1.32.23",
-        "@ciscospark/plugin-authorization": "1.32.23",
-        "@ciscospark/plugin-logger": "1.32.23",
-        "@ciscospark/plugin-memberships": "1.32.23",
-        "@ciscospark/plugin-messages": "1.32.23",
-        "@ciscospark/plugin-people": "1.32.23",
-        "@ciscospark/plugin-phone": "1.32.23",
-        "@ciscospark/plugin-rooms": "1.32.23",
-        "@ciscospark/plugin-team-memberships": "1.32.23",
-        "@ciscospark/plugin-teams": "1.32.23",
-        "@ciscospark/plugin-webhooks": "1.32.23",
-        "@ciscospark/spark-core": "1.32.23",
-        "@ciscospark/storage-adapter-local-storage": "1.32.23",
+        "@webex/internal-plugin-wdm": "1.59.0",
+        "@webex/plugin-authorization": "1.59.0",
+        "@webex/plugin-logger": "1.59.0",
+        "@webex/plugin-memberships": "1.59.0",
+        "@webex/plugin-messages": "1.59.0",
+        "@webex/plugin-people": "1.59.0",
+        "@webex/plugin-phone": "1.59.0",
+        "@webex/plugin-rooms": "1.59.0",
+        "@webex/plugin-team-memberships": "1.59.0",
+        "@webex/plugin-teams": "1.59.0",
+        "@webex/plugin-webhooks": "1.59.0",
+        "@webex/storage-adapter-local-storage": "1.59.0",
+        "@webex/webex-core": "1.59.0",
         "babel-polyfill": "^6.23.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.4"
+        "lodash": "^4.17.11"
       }
     },
     "cli-cursor": {
@@ -1286,15 +1454,14 @@
       }
     },
     "command-line-args": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.0.2.tgz",
-      "integrity": "sha512-/qPcbL8zpqg53x4rAaqMFlRV4opN3pbla7I7k9x8kyOBMQoGT6WltjN6sXZuxOXw6DgdK7Ad+ijYS5gjcr7vlA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
+      "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
       "requires": {
-        "argv-tools": "^0.1.1",
-        "array-back": "^2.0.0",
-        "find-replace": "^2.0.1",
+        "array-back": "^3.0.1",
+        "find-replace": "^3.0.0",
         "lodash.camelcase": "^4.3.0",
-        "typical": "^2.6.1"
+        "typical": "^4.0.0"
       }
     },
     "command-line-usage": {
@@ -1306,6 +1473,21 @@
         "chalk": "^2.4.1",
         "table-layout": "^0.4.3",
         "typical": "^2.6.1"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
+          "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
+          "requires": {
+            "typical": "^2.6.1"
+          }
+        },
+        "typical": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
+          "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
+        }
       }
     },
     "commander": {
@@ -1325,9 +1507,12 @@
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "content-disposition": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
     },
     "content-type": {
       "version": "1.0.4",
@@ -1335,9 +1520,9 @@
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
     },
     "cookie-signature": {
       "version": "1.0.6",
@@ -1350,9 +1535,9 @@
       "integrity": "sha1-YFiWYkBTr4wo775zXCWjAaYcZcU="
     },
     "core-js": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.4.tgz",
-      "integrity": "sha512-05qQ5hXShcqGkPZpXEFLIpxayZscVD2kuMBZewxiIPPEagukO4mqgPA9CWhUvFBJfy3ODdK2p9xyHh7FTU9/7A=="
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1437,6 +1622,14 @@
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.1.0.tgz",
       "integrity": "sha512-/TnecbwXEdycfbsM2++O3eGiatEFHjjNciHEwJclM+T5Kd94qD1AP+2elP/Mq0L5b9VZJao5znR01Mz6eX8Seg=="
     },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1507,9 +1700,9 @@
       }
     },
     "ecdsa-sig-formatter": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
-      "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -1560,10 +1753,33 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "es-abstract": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "requires": {
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
     "es6-promise": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
-      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg=="
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "es6-promisify": {
       "version": "5.0.0",
@@ -1735,9 +1951,9 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "event-target-shim": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.0.tgz",
-      "integrity": "sha512-vu4tlY5xqMEGj/rzuDHxfvm9Kk2562O5h58i8xwnkMkv/yqmBqBcDJt/vGBrOBbCKuVc5eV3ghYxAX9YUhyi0w=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "execa": {
       "version": "0.10.0",
@@ -1753,39 +1969,57 @@
         "strip-eof": "^1.0.0"
       }
     },
-    "express": {
-      "version": "4.16.4",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
-      "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
+    "exif": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/exif/-/exif-0.6.0.tgz",
+      "integrity": "sha1-YKYmaAdlQst+T1cZnUrG830sX0o=",
       "requires": {
-        "accepts": "~1.3.5",
+        "debug": "^2.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "express": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+      "requires": {
+        "accepts": "~1.3.7",
         "array-flatten": "1.1.1",
-        "body-parser": "1.18.3",
-        "content-disposition": "0.5.2",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
         "content-type": "~1.0.4",
-        "cookie": "0.3.1",
+        "cookie": "0.4.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "~1.1.2",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.1.1",
+        "finalhandler": "~1.1.2",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
         "methods": "~1.1.2",
         "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
+        "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.4",
-        "qs": "6.5.2",
-        "range-parser": "~1.2.0",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
         "safe-buffer": "5.1.2",
-        "send": "0.16.2",
-        "serve-static": "1.13.2",
-        "setprototypeof": "1.1.0",
-        "statuses": "~1.4.0",
-        "type-is": "~1.6.16",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
       },
@@ -1798,10 +2032,10 @@
             "ms": "2.0.0"
           }
         },
-        "statuses": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
         }
       }
     },
@@ -1878,16 +2112,16 @@
       "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
     },
     "finalhandler": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-      "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "statuses": "~1.4.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
         "unpipe": "~1.0.0"
       },
       "dependencies": {
@@ -1898,21 +2132,15 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "statuses": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
         }
       }
     },
     "find-replace": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-2.0.1.tgz",
-      "integrity": "sha512-LzDo3Fpa30FLIBsh6DCDnMN1KW2g4QKkqKmejlImgWY67dDFPX/x9Kh/op/GK522DchQXEvDi/wD48HKW49XOQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
       "requires": {
-        "array-back": "^2.0.0",
-        "test-value": "^3.0.0"
+        "array-back": "^3.0.1"
       }
     },
     "find-root": {
@@ -1942,9 +2170,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",
-      "integrity": "sha512-t2JCjbzxQpWvbhts3l6SH1DKzSrx8a+SsaVf4h6bG4kOXUuPYS/kg2Lr4gQSb7eemaHqJkOThF1BGyjlUkO1GQ==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
       "requires": {
         "debug": "=3.1.0"
       },
@@ -2020,6 +2248,11 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
@@ -2042,14 +2275,14 @@
       }
     },
     "gaxios": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-1.7.0.tgz",
-      "integrity": "sha512-2SaZTtaEgnSMgRrBVnPA5O9Tc8xWfnL48fuxFL7zOHZwnam3HiNOkoosnRgnkNBZoEZrH1Aja3wMCrrDtOEqUw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-1.8.4.tgz",
+      "integrity": "sha512-BoENMnu1Gav18HcpV9IleMPZ9exM+AvUjrAOV4Mzs/vfz2Lu/ABv451iEXByKiMPn2M140uul1txXCg83sAENw==",
       "requires": {
-        "abort-controller": "^2.0.2",
+        "abort-controller": "^3.0.0",
         "extend": "^3.0.2",
         "https-proxy-agent": "^2.2.1",
-        "node-fetch": "^2.2.0"
+        "node-fetch": "^2.3.0"
       }
     },
     "gcp-metadata": {
@@ -2261,6 +2494,41 @@
       "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
       "dev": true
     },
+    "gm": {
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/gm/-/gm-1.23.1.tgz",
+      "integrity": "sha1-Lt7rlYCE0PjqeYjl2ZWxx9/BR3c=",
+      "requires": {
+        "array-parallel": "~0.1.3",
+        "array-series": "~0.1.5",
+        "cross-spawn": "^4.0.0",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          }
+        },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "google-auth-library": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-2.0.2.tgz",
@@ -2273,15 +2541,32 @@
         "jws": "^3.1.5",
         "lru-cache": "^5.0.0",
         "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        }
       }
     },
     "google-p12-pem": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-1.0.3.tgz",
-      "integrity": "sha512-KGnAiMMWaJp4j4tYVvAjfP3wCKZRLv9M1Nir2wRRNWUYO7j1aX8O9Qgz+a8/EQ5rAvuo4SIu79n6SIdkNl7Msg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-1.0.4.tgz",
+      "integrity": "sha512-SwLAUJqUfTB2iS+wFfSS/G9p7bt4eWcc2LyfvmUXe7cWp6p3mpxDo6LLI29MXdU6wvPcQ/up298X7GMC5ylAlA==",
       "requires": {
-        "node-forge": "^0.7.5",
+        "node-forge": "^0.8.0",
         "pify": "^4.0.0"
+      },
+      "dependencies": {
+        "node-forge": {
+          "version": "0.8.4",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.4.tgz",
+          "integrity": "sha512-UOfdpxivIYY4g5tqp5FNRNgROVNxRACUxxJREntJLFaJr1E0UEqFtUIk0F/jYx/E+Y6sVXd0KDi/m5My0yGCVw=="
+        }
       }
     },
     "googleapis": {
@@ -2325,9 +2610,9 @@
       "dev": true
     },
     "gtoken": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-2.3.2.tgz",
-      "integrity": "sha512-F8EObUGyC8Qd3WXTloNULZBwfUsOABoHElihB1F6zGhT/cy38iPL09wGLRY712I+hQnOyA+sYlgPFX2cOKz0qg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-2.3.3.tgz",
+      "integrity": "sha512-EaB49bu/TCoNeQjhCYKI/CurooBKkGxIqFHsWABW0b25fobBYVTMe84A8EBVVZhl8emiUdNypil9huMOTmyAnw==",
       "requires": {
         "gaxios": "^1.0.4",
         "google-p12-pem": "^1.0.0",
@@ -2337,9 +2622,9 @@
       },
       "dependencies": {
         "mime": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
-          "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w=="
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
         }
       }
     },
@@ -2368,10 +2653,23 @@
         "har-schema": "^2.0.0"
       }
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -2399,14 +2697,15 @@
       "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
     },
     "http-errors": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
       "requires": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
-        "setprototypeof": "1.1.0",
-        "statuses": ">= 1.4.0 < 2"
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
       }
     },
     "http-signature": {
@@ -2437,9 +2736,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -2600,9 +2899,9 @@
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
     "ipaddr.js": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
-      "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+      "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -2610,14 +2909,19 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+      "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
     },
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
       "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-finite": {
       "version": "1.0.2",
@@ -2659,10 +2963,26 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "requires": {
+        "has": "^1.0.1"
+      }
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -2786,11 +3106,11 @@
       }
     },
     "jsonwebtoken": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.4.0.tgz",
-      "integrity": "sha512-coyXjRTCy0pw5WYBpMvWOMN+Kjaik2MwTUIq9cna/W7NpO9E+iYbumZONAz3hcr+tXFJECoQVrtmIoC3Oz0gvg==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
       "requires": {
-        "jws": "^3.1.5",
+        "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",
         "lodash.isboolean": "^3.0.3",
         "lodash.isinteger": "^4.0.4",
@@ -2798,13 +3118,14 @@
         "lodash.isplainobject": "^4.0.6",
         "lodash.isstring": "^4.0.1",
         "lodash.once": "^4.0.0",
-        "ms": "^2.1.1"
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
       },
       "dependencies": {
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -2820,21 +3141,21 @@
       }
     },
     "jwa": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.2.0.tgz",
-      "integrity": "sha512-Grku9ZST5NNQ3hqNUodSkDfEBqAmGA1R8yiyPHOnLzEKI0GaCQC/XhFmsheXYuXzFQJdILbh+lYBiliqG5R/Vg==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.10",
+        "ecdsa-sig-formatter": "1.0.11",
         "safe-buffer": "^5.0.1"
       }
     },
     "jws": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.1.tgz",
-      "integrity": "sha512-bGA2omSrFUkd72dhh05bIAN832znP4wOU3lfuXtRBuGTbsmNmDXMQg28f0Vsxaxgk4myF5YkKQpz6qeRpMgX9g==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
       "requires": {
-        "jwa": "^1.2.0",
+        "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -2844,9 +3165,9 @@
       "integrity": "sha1-XqKa/CUppCWThDfWlVtxTOapeR8="
     },
     "kleur": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.2.tgz",
-      "integrity": "sha512-3h7B2WRT5LNXOtQiAaWonilegHcPSf9nLVXlSTci8lu1dZUuui61+EsPEZqSVxY7rXYmB2DVKMQILxaO5WL61Q=="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
     },
     "lcid": {
       "version": "1.0.0",
@@ -2886,31 +3207,23 @@
       }
     },
     "localtunnel": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.9.1.tgz",
-      "integrity": "sha512-HWrhOslklDvxgOGFLxi6fQVnvpl6XdX4sPscfqMZkzi3gtt9V7LKBWYvNUcpHSVvjwCQ6xzXacVvICNbNcyPnQ==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.9.2.tgz",
+      "integrity": "sha512-NEKF7bDJE9U3xzJu3kbayF0WTvng6Pww7tzqNb/XtEARYwqw7CKEX7BvOMg98FtE9es2CRizl61gkV3hS8dqYg==",
       "requires": {
-        "axios": "0.17.1",
-        "debug": "2.6.9",
+        "axios": "0.19.0",
+        "debug": "4.1.1",
         "openurl": "1.1.1",
         "yargs": "6.6.0"
       },
       "dependencies": {
         "axios": {
-          "version": "0.17.1",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
-          "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+          "version": "0.19.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+          "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
           "requires": {
-            "follow-redirects": "^1.2.5",
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
+            "follow-redirects": "1.5.10",
+            "is-buffer": "^2.0.2"
           }
         }
       }
@@ -2944,6 +3257,63 @@
         "tslib": "^1.7.1"
       }
     },
+    "lodash._arraycopy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+      "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE="
+    },
+    "lodash._arrayeach": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+      "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754="
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "requires": {
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
+      }
+    },
+    "lodash._baseclone": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
+      "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
+      "requires": {
+        "lodash._arraycopy": "^3.0.0",
+        "lodash._arrayeach": "^3.0.0",
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basefor": "^3.0.0",
+        "lodash.isarray": "^3.0.0",
+        "lodash.keys": "^3.0.0"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
+    },
+    "lodash._basefor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+      "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI="
+    },
+    "lodash._bindcallback": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
+    },
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
@@ -2954,6 +3324,30 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
+    "lodash.clone": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+      "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
+    },
+    "lodash.clonedeep": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
+      "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
+      "requires": {
+        "lodash._baseclone": "^3.0.0",
+        "lodash._bindcallback": "^3.0.0"
+      }
+    },
+    "lodash.fill": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.fill/-/lodash.fill-3.4.0.tgz",
+      "integrity": "sha1-o8dK5kDQU63w3CB5+HIHiOi/74U="
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -2963,6 +3357,21 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.intersection": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.intersection/-/lodash.intersection-4.4.0.tgz",
+      "integrity": "sha1-ChG6Yx0OlcI8fy9Mu5ppLtF45wU="
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
     },
     "lodash.isboolean": {
       "version": "3.0.3",
@@ -2989,6 +3398,26 @@
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "requires": {
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
+    "lodash.merge": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+    },
+    "lodash.omit": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
+    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -2998,6 +3427,16 @@
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
       "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4="
+    },
+    "lodash.partialright": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.partialright/-/lodash.partialright-4.2.1.tgz",
+      "integrity": "sha1-ATDYDoM2MmTUAHTzKbij56ihzEs="
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
     },
     "lodash.sample": {
       "version": "4.2.1",
@@ -3014,6 +3453,11 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
+    "long": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+      "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
+    },
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
@@ -3024,11 +3468,19 @@
       }
     },
     "lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "requires": {
-        "yallist": "^3.0.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        }
       }
     },
     "ltx": {
@@ -3057,6 +3509,13 @@
         "charenc": "~0.0.1",
         "crypt": "~0.0.1",
         "is-buffer": "~1.1.1"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+        }
       }
     },
     "md5.js": {
@@ -3109,9 +3568,9 @@
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "mime": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
       "version": "1.37.0",
@@ -3398,9 +3857,9 @@
       }
     },
     "negotiator": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "neo-async": {
       "version": "2.6.0",
@@ -3447,6 +3906,62 @@
         }
       }
     },
+    "node-jose": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/node-jose/-/node-jose-0.11.1.tgz",
+      "integrity": "sha512-1mX5prmancKdOgMI/85uduqWNFg63traxVdun7dNNsX4AUs6HqztJhzfBlIWfSujQ8Rah9dWLGUFlXORxZvvzg==",
+      "requires": {
+        "b64u": "^2.0.0",
+        "es6-promise": "^4.0.5",
+        "lodash.assign": "^4.0.8",
+        "lodash.clone": "^4.3.2",
+        "lodash.fill": "^3.2.2",
+        "lodash.flatten": "^4.2.0",
+        "lodash.intersection": "^4.1.2",
+        "lodash.merge": "^4.3.5",
+        "lodash.omit": "^4.2.1",
+        "lodash.partialright": "^4.1.3",
+        "lodash.pick": "^4.2.0",
+        "lodash.uniq": "^4.2.1",
+        "long": "^3.1.0",
+        "node-forge": "^0.7.1",
+        "uuid": "^3.0.1"
+      }
+    },
+    "node-kms": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/node-kms/-/node-kms-0.3.2.tgz",
+      "integrity": "sha1-beflJICO7ATHf+6072SUDlDit1k=",
+      "requires": {
+        "es6-promise": "^2.0.1",
+        "lodash.clone": "^3.0.2",
+        "lodash.clonedeep": "^3.0.1",
+        "node-jose": ">=0.3.0 <1.0",
+        "uuid": "^2.0.1"
+      },
+      "dependencies": {
+        "es6-promise": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
+          "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw="
+        },
+        "lodash.clone": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-3.0.3.tgz",
+          "integrity": "sha1-hGiMc9MrWpDKJWFpY/GJJSqZcEM=",
+          "requires": {
+            "lodash._baseclone": "^3.0.0",
+            "lodash._bindcallback": "^3.0.0",
+            "lodash._isiterateecall": "^3.0.0"
+          }
+        },
+        "uuid": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
+        }
+      }
+    },
     "node-pre-gyp": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz",
@@ -3471,6 +3986,33 @@
           "requires": {
             "abbrev": "1",
             "osenv": "^0.1.4"
+          }
+        }
+      }
+    },
+    "node-scr": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/node-scr/-/node-scr-0.2.2.tgz",
+      "integrity": "sha1-VCqtdCAQ0S5Bm1kG2lFq+d6jBdo=",
+      "requires": {
+        "es6-promise": "^2.0.1",
+        "lodash.clone": "^3.0.2",
+        "node-jose": ">=0.3.0 <1.0"
+      },
+      "dependencies": {
+        "es6-promise": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
+          "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw="
+        },
+        "lodash.clone": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-3.0.3.tgz",
+          "integrity": "sha1-hGiMc9MrWpDKJWFpY/GJJSqZcEM=",
+          "requires": {
+            "lodash._baseclone": "^3.0.0",
+            "lodash._bindcallback": "^3.0.0",
+            "lodash._isiterateecall": "^3.0.0"
           }
         }
       }
@@ -3635,6 +4177,11 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+    },
     "octokit-pagination-methods": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
@@ -3778,12 +4325,12 @@
       }
     },
     "parse-headers": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
-      "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.2.tgz",
+      "integrity": "sha512-/LypJhzFmyBIDYP9aDVgeyEb5sQfbfY5mnDq4hVhlQ69js87wXfmEI5V3xI6vvXasqebp0oCytYFLxsBVfCzSg==",
       "requires": {
-        "for-each": "^0.3.2",
-        "trim": "0.0.1"
+        "for-each": "^0.3.3",
+        "string.prototype.trim": "^1.1.2"
       }
     },
     "parse-json": {
@@ -3795,9 +4342,9 @@
       }
     },
     "parseurl": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
     "path-exists": {
       "version": "2.1.0",
@@ -3931,13 +4478,18 @@
       }
     },
     "proxy-addr": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
-      "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
+      "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
       "requires": {
         "forwarded": "~0.1.2",
-        "ipaddr.js": "1.8.0"
+        "ipaddr.js": "1.9.0"
       }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
       "version": "1.1.31",
@@ -3989,19 +4541,29 @@
       "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ=="
     },
     "range-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "raw-body": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
-      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
       "requires": {
-        "bytes": "3.0.0",
-        "http-errors": "1.6.3",
-        "iconv-lite": "0.4.23",
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        }
       }
     },
     "rc": {
@@ -4276,9 +4838,9 @@
       "integrity": "sha512-XAVZQO4qsfzVTHorF49zCpkdxiGmPNjA8ps8RcJGtGP3QJ/A8I9/SVg/QnkAFDMXIyGbHZBBFwYBw6WdnhT96w=="
     },
     "sdp-transform": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.7.0.tgz",
-      "integrity": "sha512-v8/zfKeDKBEXKMf4UT91owHoXM6O+s8gEVtCVSvrAd2eEtuv5u4TKcTXX4a9qrQM3T2Ycr9rLyU+Ww3ZiCiaGQ=="
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.8.0.tgz",
+      "integrity": "sha512-0sacVJs3KzYVm89QDRiZN5eWjBidSGB4F2oYuMOhHfdiKzkZVAhh/UOG5XzjaSlrhWVHxqR7MpQe5lWA9DfsSg=="
     },
     "semver": {
       "version": "5.6.0",
@@ -4286,9 +4848,9 @@
       "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
     },
     "send": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
       "requires": {
         "debug": "2.6.9",
         "depd": "~1.1.2",
@@ -4297,12 +4859,12 @@
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "~1.6.2",
-        "mime": "1.4.1",
-        "ms": "2.0.0",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
         "on-finished": "~2.3.0",
-        "range-parser": "~1.2.0",
-        "statuses": "~1.4.0"
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
       },
       "dependencies": {
         "debug": {
@@ -4311,24 +4873,31 @@
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
           }
         },
-        "statuses": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
     },
     "serve-static": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
       "requires": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
-        "parseurl": "~1.3.2",
-        "send": "0.16.2"
+        "parseurl": "~1.3.3",
+        "send": "0.17.1"
       }
     },
     "set-blocking": {
@@ -4337,9 +4906,9 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "setprototypeof": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -4466,6 +5035,16 @@
         "strip-ansi": "^3.0.0"
       }
     },
+    "string.prototype.trim": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.0",
+        "function-bind": "^1.0.2"
+      }
+    },
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -4569,6 +5148,21 @@
         "lodash.padend": "^4.6.1",
         "typical": "^2.6.1",
         "wordwrapjs": "^3.0.0"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
+          "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
+          "requires": {
+            "typical": "^2.6.1"
+          }
+        },
+        "typical": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
+          "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
+        }
       }
     },
     "tar": {
@@ -4644,15 +5238,6 @@
         }
       }
     },
-    "test-value": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
-      "integrity": "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==",
-      "requires": {
-        "array-back": "^2.0.0",
-        "typical": "^2.6.1"
-      }
-    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -4703,6 +5288,11 @@
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
       "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
     },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
     "tough-cookie": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
@@ -4718,11 +5308,6 @@
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         }
       }
-    },
-    "trim": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
     },
     "trim-newlines": {
       "version": "1.0.0",
@@ -4748,27 +5333,20 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "twilio": {
-      "version": "3.28.0",
-      "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.28.0.tgz",
-      "integrity": "sha512-wsBU2+4bWpuhVl4ZjYPaR7WYD2U27ghALclK2Jg9pp4RgtD0EhPMIhTFWkGJ8+zUqdIW/ZkYA/4UocDx9vdoQw==",
+      "version": "3.31.1",
+      "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.31.1.tgz",
+      "integrity": "sha512-mrJn52HpWKcC0tLetrCpo26V7MfMJqGkpDqiqsWlhbQXqj/MORRsEEPahF2mBxpPqaZTTmmZvshQPUQB+kj/WA==",
       "requires": {
-        "@types/express": "^4.11.1",
+        "@types/express": "^4.16.1",
         "deprecate": "1.0.0",
-        "jsonwebtoken": "^8.1.0",
-        "lodash": "^4.17.10",
-        "moment": "2.19.3",
+        "jsonwebtoken": "^8.5.1",
+        "lodash": "^4.17.11",
+        "moment": "^2.24.0",
         "q": "2.0.x",
-        "request": "^2.87.0",
+        "request": "^2.88.0",
         "rootpath": "0.1.2",
         "scmp": "2.0.0",
         "xmlbuilder": "9.0.1"
-      },
-      "dependencies": {
-        "moment": {
-          "version": "2.19.3",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.3.tgz",
-          "integrity": "sha1-vbmdJw1tf9p4zA+6zoVeJ/59pp8="
-        }
       }
     },
     "type-check": {
@@ -4781,18 +5359,33 @@
       }
     },
     "type-is": {
-      "version": "1.6.16",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
-      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "~2.1.18"
+        "mime-types": "~2.1.24"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.40.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+          "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+        },
+        "mime-types": {
+          "version": "2.1.24",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+          "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+          "requires": {
+            "mime-db": "1.40.0"
+          }
+        }
       }
     },
     "typical": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
     },
     "uglify-js": {
       "version": "3.4.9",
@@ -4962,6 +5555,13 @@
       "requires": {
         "reduce-flatten": "^1.0.1",
         "typical": "^2.6.1"
+      },
+      "dependencies": {
+        "typical": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
+          "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
+        }
       }
     },
     "wrap-ansi": {
@@ -4996,9 +5596,9 @@
       }
     },
     "ws": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.3.tgz",
-      "integrity": "sha512-tbSxiT+qJI223AP4iLfQbkbxkwdFcneYinM2+x46Gx2wgvbaOMO36czfdfVUBRTHvzAMRhDd98sA5d/BuWbQdg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
       "requires": {
         "async-limiter": "~1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@octokit/rest": "^16.15.0",
     "app-root-path": "^2.0.1",
-    "botkit": "^0.7.2",
+    "botkit": "^0.7.4",
     "botkit-storage-mongo": "^1.0.7",
     "cheese-name": "^1.0.0",
     "dotenv": "^6.2.0",


### PR DESCRIPTION
Update botkit from 0.7.2 to 0.7.4. This indirectly updates axios to
resolve warnings with `npm audit`.