### PR TITLE
chore: remove deprecated serverless configuration setting

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -5,7 +5,6 @@ provider:
   region: us-west-2
   name: aws
   runtime: nodejs14.x
-  lambdaHashingVersion: 20201221
   environment:
     SLACK_SIGNING_SECRET: ${env:SLACK_SIGNING_SECRET}
     SLACK_BOT_TOKEN: ${env:SLACK_BOT_TOKEN}


### PR DESCRIPTION
From https://www.serverless.com/framework/docs/deprecations:

"If you previously opted-in to use new algorithm by setting
provider.lambdaHashingVersion to 20201221, you can safely remove that
property from your configuration to silence the deprecation."

Closes: https://github.com/ucsf-ckm/zorgbort/issues/130