### PR TITLE
chore: bump serverless-offline from 8.5.0 to 8.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -320,9 +320,9 @@
       }
     },
     "@hapi/teamwork": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.0.tgz",
-      "integrity": "sha512-llqoQTrAJDTXxG3c4Kz/uzhBS1TsmSBa/XG5SPcVXgmffHE1nFtyLIK0hNJHCB3EuBKT84adzd1hZNY9GJLWtg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.1.tgz",
+      "integrity": "sha512-1oPx9AE5TIv+V6Ih54RP9lTZBso3rP8j4Xhb6iSVwPXtAM+sDopl5TFMv5Paw73UnpZJ9gjcrTE1BXrWt9eQrg==",
       "dev": true
     },
     "@hapi/topo": {
@@ -4977,46 +4977,6 @@
         "semver-compare": "^1.0.0"
       }
     },
-    "portfinder": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
-      "integrity": "sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==",
-      "dev": true,
-      "requires": {
-        "async": "^2.6.2",
-        "debug": "^3.1.1",
-        "mkdirp": "^0.5.5"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.14"
-          }
-        },
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.6"
-          }
-        }
-      }
-    },
     "pre-commit": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
@@ -5659,15 +5619,15 @@
       }
     },
     "serverless-offline": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/serverless-offline/-/serverless-offline-8.5.0.tgz",
-      "integrity": "sha512-72UroBrXOp2JAhIdrf+/6K8JZeH4m2Jv5UYQFudmsFMafgvNRvVk4y4miTNhJkXP35GUhUNhD4fyuPOkUpa7XA==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/serverless-offline/-/serverless-offline-8.7.0.tgz",
+      "integrity": "sha512-OqBfSFk4iuhBx6oXxLLRY7QKNVzBIZBnhgeG/4GmJ+dG93AGYts0BD6Myi5EZALCD8T6WYQiNwHQRPDyGIgz2w==",
       "dev": true,
       "requires": {
         "@hapi/boom": "^9.1.4",
         "@hapi/h2o2": "^9.1.0",
         "@hapi/hapi": "^20.2.1",
-        "aws-sdk": "^2.1076.0",
+        "aws-sdk": "^2.1097.0",
         "boxen": "^5.1.2",
         "chalk": "^4.1.2",
         "cuid": "^2.1.8",
@@ -5688,7 +5648,6 @@
         "p-queue": "^6.6.2",
         "p-retry": "^4.6.1",
         "please-upgrade-node": "^3.2.0",
-        "portfinder": "^1.0.28",
         "semver": "^7.3.5",
         "update-notifier": "^5.1.0",
         "velocityjs": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "pre-commit": "^1.2.2",
     "prettier": "^2.6.0",
     "serverless": "^3.12.0",
-    "serverless-offline": "^8.5.0"
+    "serverless-offline": "^8.7.0"
   },
   "pre-commit": [
     "lint"


### PR DESCRIPTION
Fixes: https://github.com/ucsf-ckm/zorgbort/security/dependabot/13