### PR TITLE
Add some deploy options

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,9 +1,12 @@
 name: Deploy Dev Build
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
+
+concurrency: deploy-dev
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -5,6 +5,8 @@ on:
     tags:
       - '*'
 
+concurrency: deploy-prod
+
 jobs:
   deploy:
     name: Deploy Lambda Function


### PR DESCRIPTION
Allow the dev build to be deployed manually in cases where a dependabot
update has been automerged which won't trigger other actions.
Also added some concurency protection for multiple builds getting
deployed at the same time.